### PR TITLE
Release 0.2

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -30,7 +30,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: Run unit tests
-        run: pytest test/ --cov=changelist_foci --cov-report=html --cov-fail-under=70
+        run: pytest test/ --cov=changelist_foci --cov-report=html --cov-fail-under=75
 
       - name: Upload Test Coverage Reports
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ If the `workspace_path` argument is not provided, it is assumed that the current
 The Changelist name is an optional argument, that is used to select which Changelist to obtain the FOCI for.
 
 If the changelist name is not provided, it is assumed that the active changelist `(default = true)` will be the target of the operation.
+
+## File Format Flags
+**Full Path:** `--full-path`
+The full path of the file is given in Line Subjects.
+ - Includes the first slash of directories in the project root (removed by default). 
+
+**File Extension:** `--no-file-ext` or `-x`
+Remove the File Extension from File Names.
+
+**File Name:** `--filename` or `-f`
+Include only the File Name in Subject Lines.
+ - Removes the whole path to the File.
+ - May be combined with the File Extension flag.

--- a/changelist_foci/__init__.py
+++ b/changelist_foci/__init__.py
@@ -17,7 +17,7 @@ def get_changelist_foci(
     Returns:
     str - The FOCI formatted output.
     """
-    return _get_change_list(input_data).get_foci()
+    return _get_change_list(input_data).get_foci(input_data.format_options)
 
 
 def _get_change_list(input_data: InputData) -> ChangelistData:

--- a/changelist_foci/change_data.py
+++ b/changelist_foci/change_data.py
@@ -2,6 +2,8 @@
 """
 from dataclasses import dataclass
 
+from changelist_foci.format_options import FormatOptions
+
 
 @dataclass(frozen=True)
 class ChangeData:
@@ -18,35 +20,32 @@ class ChangeData:
     after_path: str | None = None
     after_dir: bool | None = None
 
-    def get_subject(self) -> str:
+    def get_subject(
+        self,
+        format_options: FormatOptions = FormatOptions()
+    ) -> str:
         """
+        Obtain the FOCI Subject, categorizing the change and applying Format Options.
+        
+        Parameters:
+        - format_options (FormatOptions): A dataclass collection of format flags.
+
+        Returns:
+        str - The Subject Line for this Change Data.
         """
         if self.before_path is None:
             if self.after_path is None:
-                exit('Empty Change Data')
-            # todo: Process the After Path
-            file_name = _get_file_name(self.after_path)
-            return f"Create {file_name}"
-        elif self.after_path is None:
-            # todo: Process Before Path
-            file_name = _get_file_name(self.before_path)
-            return f"Remove {file_name}"
-        else:
-            name_before = _get_file_name(self.before_path)
-            name_after = _get_file_name(self.after_path)
-            # Compare name changes
-            if name_before == name_after:
-                return f"Update {name_before}"
-            #
-            return f"Move {name_before} to {name_after}"
-
-def _get_file_name(path_value: str) -> str:
-    """
-    """
-    root_def = '$PROJECT_DIR$'
-    if not path_value.startswith(root_def):
-        exit("Path Values must start with project root.")
-    # 
-    rel_path = path_value[len(root_def):]
-    #
-    return rel_path
+                return ''
+            # Only the After Path exists
+            return f"Create {format_options.format(self.after_path)}"
+        # Process and Format the Before Path
+        name_before = format_options.format(self.before_path)
+        # Check for the After Path
+        if self.after_path is None:
+            return f"Remove {name_before}"
+        # Compare Both Full Paths
+        if self.before_path == self.after_path:
+            return f"Update {name_before}"
+        # Different Before and After Paths
+        name_after = format_options.format(self.after_path)
+        return f"Move {name_before} to {name_after}"

--- a/changelist_foci/changelist_data.py
+++ b/changelist_foci/changelist_data.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from changelist_foci.change_data import ChangeData
+from changelist_foci.format_options import FormatOptions
 
 
 @dataclass(frozen=True)
@@ -23,12 +24,23 @@ class ChangelistData:
     comment: str = ""
     is_default: bool = False
 
-    def get_foci(self) -> str:
+    def get_foci(
+        self,
+        format_options: FormatOptions = FormatOptions(),
+    ) -> str:
         """
         Obtain the FOCI of a Changelist.
+
+        Parameters:
+        - format_options (FormatOptions): The Options controlling text and line formatting.
 
         Returns:
         str - The FOCI string.
         """
-        subject_lines = "\n".join(map(lambda x: f"* {x.get_subject()}", self.changes))
+        subject_lines = "\n".join(
+            map(
+                lambda x: f"* {x.get_subject(format_options)}",
+                self.changes
+            )
+        )
         return f"{self.name}:\n" + subject_lines

--- a/changelist_foci/format_options.py
+++ b/changelist_foci/format_options.py
@@ -1,0 +1,45 @@
+"""The Options for Output Formatting.
+"""
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FormatOptions:
+    """
+    Attributes:
+    - full_path (bool): Whether to display the full path to the file.
+    - no_file_ext (bool): Whether to filter file extensions (except move with different extensions).
+    - file_name (bool): Whether to display the file name. Removes any parent directories.
+    """
+    full_path: bool = False
+    no_file_ext: bool = False
+    file_name: bool = False
+
+    def format(self, path: str) -> str:
+        """Format a Path String, applying the given options.
+
+        Parameters:
+        - path (str): The relative (project root) path string in Change Data.
+
+        Returns:
+        str - Formatted File Information.
+        """
+        if self.full_path:
+            if self.no_file_ext:
+                # Filter the File Ext
+                return os.path.splitext(path)[0]
+            # No Change Necessary
+            return path
+        if self.file_name:
+            basename = os.path.basename(path)
+            if self.no_file_ext:
+                # Filter the File Ext
+                return os.path.splitext(basename)[0]
+            return basename
+        # Remove the initial slash char
+        path = path.lstrip('/')
+        if self.no_file_ext:
+            # Filter the File Ext
+            return os.path.splitext(path)[0]    
+        return path

--- a/changelist_foci/input/__init__.py
+++ b/changelist_foci/input/__init__.py
@@ -27,7 +27,7 @@ def validate_input(arguments: list[str]) -> InputData:
         format_options=FormatOptions(
             full_path=arg_data.full_path,
             no_file_ext=arg_data.no_file_ext,
-            file_name=arg_data.file_name,
+            file_name=arg_data.filename,
         )
     )
 

--- a/changelist_foci/input/__init__.py
+++ b/changelist_foci/input/__init__.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from sys import exit
 
+from changelist_foci.format_options import FormatOptions
 from changelist_foci.input.argument_parser import parse_arguments
 from changelist_foci.input.file_validation import validate_input_file
 from changelist_foci.input.input_data import InputData
@@ -22,7 +23,12 @@ def validate_input(arguments: list[str]) -> InputData:
     return InputData(
         workspace_xml=_find_workspace_xml() if arg_data.workspace_path is None
             else validate_input_file(arg_data.workspace_path),
-        changelist_name=arg_data.changelist_name
+        changelist_name=arg_data.changelist_name,
+        format_options=FormatOptions(
+            full_path=arg_data.full_path,
+            no_file_ext=arg_data.no_file_ext,
+            file_name=arg_data.file_name,
+        )
     )
 
 

--- a/changelist_foci/input/argument_data.py
+++ b/changelist_foci/input/argument_data.py
@@ -19,10 +19,10 @@ class ArgumentData:
     - workspace_path (str | None): The path to the Workspace.xml file, or none if the cwd is project root.
     - full_path (bool): Display the Full File Path.
     - no_file_ext (bool): Remove the File Extension.
-    - file_name (bool): Remove the Parent Directories.
+    - filename (bool): Remove the Parent Directories.
     """
     changelist_name: str | None
     workspace_path: str | None
     full_path: bool
     no_file_ext: bool
-    file_name: bool
+    filename: bool

--- a/changelist_foci/input/argument_data.py
+++ b/changelist_foci/input/argument_data.py
@@ -17,6 +17,12 @@ class ArgumentData:
     Fields:
     - changelist_name (str | None): The name of the changelist, or None to use the Active Changelist.
     - workspace_path (str | None): The path to the Workspace.xml file, or none if the cwd is project root.
+    - full_path (bool): Display the Full File Path.
+    - no_file_ext (bool): Remove the File Extension.
+    - file_name (bool): Remove the Parent Directories.
     """
     changelist_name: str | None
     workspace_path: str | None
+    full_path: bool
+    no_file_ext: bool
+    file_name: bool

--- a/changelist_foci/input/argument_parser.py
+++ b/changelist_foci/input/argument_parser.py
@@ -60,7 +60,7 @@ def _validate_arguments(
         workspace_path=path,
         full_path=parsed_args.full_path,
         no_file_ext=parsed_args.no_file_ext,
-        file_name=parsed_args.filename,
+        filename=parsed_args.filename,
     )
 
 

--- a/changelist_foci/input/argument_parser.py
+++ b/changelist_foci/input/argument_parser.py
@@ -58,6 +58,9 @@ def _validate_arguments(
     return ArgumentData(
         changelist_name=changelist,
         workspace_path=path,
+        full_path=parsed_args.full_path,
+        no_file_ext=parsed_args.no_file_ext,
+        file_name=parsed_args.filename,
     )
 
 
@@ -84,5 +87,23 @@ def _define_arguments() -> ArgumentParser:
         type=str,
         default=None,
         help='The Path to the workspace file, or none if cwd is the project root.',
+    )
+    parser.add_argument(
+        '--full-path',
+        action='store_true',
+        default=False,
+        help='Display the Full File Path.',
+    )
+    parser.add_argument(
+        '--no-file-ext', '-x',
+        action='store_true',
+        default=False,
+        help='Remove File Extension from File paths.',
+    )
+    parser.add_argument(
+        '--filename', '-f',
+        action='store_true',
+        default=False,
+        help='Remove Parent Directories from File paths.',
     )
     return parser

--- a/changelist_foci/input/input_data.py
+++ b/changelist_foci/input/input_data.py
@@ -2,6 +2,8 @@
 """
 from dataclasses import dataclass
 
+from changelist_foci.format_options import FormatOptions
+
 
 @dataclass(frozen=True)
 class InputData:
@@ -10,6 +12,8 @@ class InputData:
     Fields:
     - workspace_xml (str): The contents of the workspace.xml file.
     - changelist_name (str): The name of the Changelist, or None.
+    - format_options (FormatOptions): The options for output formatting.
     """
     workspace_xml: str
     changelist_name: str | None = None
+    format_options: FormatOptions = FormatOptions()

--- a/changelist_foci/workspace_reader.py
+++ b/changelist_foci/workspace_reader.py
@@ -68,21 +68,34 @@ def _extract_changelist_manager(workspace_xml: str) -> Element | None:
     return None
 
 
+_PROJECT_DIR_VAR = '$PROJECT_DIR$'
+_PROJECT_DIR_LEN = len(_PROJECT_DIR_VAR)
+
+def _filter_project_dir(path_str: str | None) -> str:
+    """Filter the ProjectDir string at the beginning of the path.
+    """
+    if path_str is None:
+        return None
+    if path_str.startswith(_PROJECT_DIR_VAR):
+        return path_str[_PROJECT_DIR_LEN:]
+    return path_str
+
+
 def _extract_change_data(list_element: Element) -> list[ChangeData]:
     """
     Given a ChangeList XML Element, obtain the List of Changes.
 
     Parameters:
-    - changelist_element (Element): 
+    - list_element (Element): 
 
     Returns:
     list[ChangeData] - The list of structured ChangeData.
     """
     return [
         ChangeData(
-            before_path=get_attr(change, 'beforePath'),
+            before_path=_filter_project_dir(get_attr(change, 'beforePath')),
             before_dir=get_attr(change, 'beforeDir'),
-            after_path=get_attr(change, 'afterPath'),
+            after_path=_filter_project_dir(get_attr(change, 'afterPath')),
             after_dir=get_attr(change, 'afterDir'),
         ) for change in filter(lambda x: x.tag == 'change', list_element)
     ]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="changelist-foci",
-    version="0.1.1",
+    version="0.2",
 	description='Changelist FOCI',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/input/test_argument_parser.py
+++ b/test/input/test_argument_parser.py
@@ -9,7 +9,7 @@ def test_parse_arguments_empty_list():
     assert result.workspace_path is None
     assert not result.full_path
     assert not result.no_file_ext
-    assert not result.file_name
+    assert not result.filename
 
 
 def test_parse_arguments_change_list_main():
@@ -18,7 +18,7 @@ def test_parse_arguments_change_list_main():
     assert result.workspace_path is None
     assert not result.full_path
     assert not result.no_file_ext
-    assert not result.file_name
+    assert not result.filename
 
 
 def test_parse_arguments_filename_plus_no_file_ext():
@@ -27,7 +27,7 @@ def test_parse_arguments_filename_plus_no_file_ext():
     assert result.workspace_path is None
     assert not result.full_path
     assert result.no_file_ext
-    assert result.file_name
+    assert result.filename
 
 
 def test_parse_arguments_filename():
@@ -36,7 +36,7 @@ def test_parse_arguments_filename():
     assert result.workspace_path is None
     assert not result.full_path
     assert not result.no_file_ext
-    assert result.file_name
+    assert result.filename
 
 
 def test_parse_arguments_no_file_ext():
@@ -45,7 +45,7 @@ def test_parse_arguments_no_file_ext():
     assert result.workspace_path is None
     assert not result.full_path
     assert result.no_file_ext
-    assert not result.file_name
+    assert not result.filename
 
 
 def test_parse_arguments_full_path():
@@ -54,7 +54,7 @@ def test_parse_arguments_full_path():
     assert result.workspace_path is None
     assert result.full_path
     assert not result.no_file_ext
-    assert not result.file_name
+    assert not result.filename
 
 
 def test_parse_arguments_changelist_filename():
@@ -63,4 +63,4 @@ def test_parse_arguments_changelist_filename():
     assert result.workspace_path is None
     assert not result.full_path
     assert not result.no_file_ext
-    assert result.file_name
+    assert result.filename

--- a/test/input/test_argument_parser.py
+++ b/test/input/test_argument_parser.py
@@ -7,10 +7,60 @@ def test_parse_arguments_empty_list():
     result = parse_arguments('')
     assert result.changelist_name == None
     assert result.workspace_path is None
+    assert not result.full_path
+    assert not result.no_file_ext
+    assert not result.file_name
 
 
 def test_parse_arguments_change_list_main():
     result = parse_arguments(['--changelist', 'Main'])
     assert result.changelist_name == 'Main'
     assert result.workspace_path is None
+    assert not result.full_path
+    assert not result.no_file_ext
+    assert not result.file_name
 
+
+def test_parse_arguments_filename_plus_no_file_ext():
+    result = parse_arguments(['-fx'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert result.no_file_ext
+    assert result.file_name
+
+
+def test_parse_arguments_filename():
+    result = parse_arguments(['-f'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert not result.no_file_ext
+    assert result.file_name
+
+
+def test_parse_arguments_no_file_ext():
+    result = parse_arguments(['-x'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert result.no_file_ext
+    assert not result.file_name
+
+
+def test_parse_arguments_full_path():
+    result = parse_arguments(['--full-path'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert result.full_path
+    assert not result.no_file_ext
+    assert not result.file_name
+
+
+def test_parse_arguments_changelist_filename():
+    result = parse_arguments(['--changelist', "Main", '-f'])
+    assert result.changelist_name == 'Main'
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert not result.no_file_ext
+    assert result.file_name

--- a/test/test_change_data.py
+++ b/test/test_change_data.py
@@ -1,18 +1,18 @@
 """Testing ChangeData Methods.
 """
 from changelist_foci.change_data import ChangeData
+from changelist_foci.format_options import FormatOptions
 
 
-PROJECT_DIR = '$PROJECT_DIR$'
-REL_FILE_PATH_1 = '/main_package/__main__.py'
-REL_FILE_PATH_2 = '/main_package/__init__.py'
+REL_FILE_PATH_1 = 'main_package/__main__.py'
+REL_FILE_PATH_2 = 'main_package/__init__.py'
 
 
 def get_before_cd():
     """
     """
     return ChangeData(
-        before_path=f'{PROJECT_DIR}{REL_FILE_PATH_1}',
+        before_path=f'/{REL_FILE_PATH_1}',
         before_dir=False,
     )
 
@@ -20,7 +20,7 @@ def get_after_cd():
     """
     """
     return ChangeData(
-        after_path=f'{PROJECT_DIR}{REL_FILE_PATH_1}',
+        after_path=f'/{REL_FILE_PATH_1}',
         after_dir=False,
     )
 
@@ -28,9 +28,9 @@ def get_both_cd():
     """
     """
     return ChangeData(
-        before_path=f'{PROJECT_DIR}{REL_FILE_PATH_1}',
+        before_path=f'/{REL_FILE_PATH_1}',
         before_dir=False,
-        after_path=f'{PROJECT_DIR}{REL_FILE_PATH_1}',
+        after_path=f'/{REL_FILE_PATH_1}',
         after_dir=False,
     )
 
@@ -38,9 +38,9 @@ def get_move_cd():
     """
     """
     return ChangeData(
-        before_path=f'{PROJECT_DIR}{REL_FILE_PATH_2}',
+        before_path=f'/{REL_FILE_PATH_2}',
         before_dir=False,
-        after_path=f'{PROJECT_DIR}{REL_FILE_PATH_1}',
+        after_path=f'/{REL_FILE_PATH_1}',
         after_dir=False,
     )
 
@@ -63,3 +63,28 @@ def test_change_data_get_subject_both_returns_str():
 def test_change_data_get_subject_move_returns_str():
     result = get_move_cd().get_subject()
     assert result == f'Move {REL_FILE_PATH_2} to {REL_FILE_PATH_1}'
+
+
+def test_get_subject_format_no_file_ext_returns_str():
+    result = get_before_cd().get_subject(FormatOptions(no_file_ext=True))
+    assert result == f"Remove main_package/__main__"
+
+
+def test_get_subject_remove_format_no_file_ext_returns_str():
+    result = get_before_cd().get_subject(FormatOptions(no_file_ext=True))
+    assert result == f"Remove main_package/__main__"
+
+
+def test_get_subject_create_format_no_file_ext_returns_str():
+    result = get_after_cd().get_subject(FormatOptions(no_file_ext=True))
+    assert result == f"Create main_package/__main__"
+
+
+def test_get_subject_update_format_no_file_ext_returns_str():
+    result = get_both_cd().get_subject(FormatOptions(no_file_ext=True))
+    assert result == f"Update main_package/__main__"
+
+
+def test_get_subject_move_format_no_file_ext_returns_str():
+    result = get_move_cd().get_subject(FormatOptions(no_file_ext=True))
+    assert result == f"Move main_package/__init__ to main_package/__main__"

--- a/test/test_changelist_data.py
+++ b/test/test_changelist_data.py
@@ -1,0 +1,57 @@
+"""Testing ChangeList Data
+"""
+
+from fileinput import filename
+from changelist_foci.change_data import ChangeData
+from changelist_foci.changelist_data import ChangelistData
+from changelist_foci.format_options import FormatOptions
+
+
+def get_cl0():
+    return ChangelistData(
+        id="0",
+        name="",
+        changes=list(),
+    )
+
+def get_cl1():
+    return ChangelistData(
+        id="1212434",
+        name="ChangeList",
+        changes=[
+            ChangeData(
+                after_path="/module/file.txt",
+                after_dir=False,
+            )
+        ],
+    )
+
+
+def test_get_foci_0_returns_error():
+    result = get_cl0().get_foci()
+    assert result == ":\n"
+
+    
+def test_get_foci_1_returns_str():
+    result = get_cl1().get_foci()
+    assert result == "ChangeList:\n* Create module/file.txt"
+
+
+def test_get_foci_1_full_path_returns_str():
+    result = get_cl1().get_foci(FormatOptions(full_path=True))
+    assert result == "ChangeList:\n* Create /module/file.txt"
+
+    
+def test_get_foci_1_no_file_ext_returns_str():
+    result = get_cl1().get_foci(FormatOptions(no_file_ext=True))
+    assert result == "ChangeList:\n* Create module/file"
+
+
+def test_get_foci_1_filename_returns_str():
+    result = get_cl1().get_foci(FormatOptions(file_name=True))
+    assert result == "ChangeList:\n* Create file.txt"
+
+
+def test_get_foci_1_filename_plus_no_file_ext_returns_str():
+    result = get_cl1().get_foci(FormatOptions(file_name=True, no_file_ext=True))
+    assert result == "ChangeList:\n* Create file"

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -60,12 +60,12 @@ def test_get_change_list_multi_select_active_():
     assert result.id == 'af84ea1b-1b24-407d-970f-9f3a2835e933'
     assert len(result.changes) == 2
     change1 = result.changes[0]
-    assert change1.before_path == '$PROJECT_DIR$/history.py'
+    assert change1.before_path == '/history.py'
     assert change1.before_dir == 'false'
     assert change1.after_path == None
     assert change1.after_dir == None
     change2 = result.changes[1]
-    assert change2.before_path == '$PROJECT_DIR$/main.py'
+    assert change2.before_path == '/main.py'
     assert change2.before_dir == 'false'
     assert change1.after_path == None
     assert change1.after_dir == None


### PR DESCRIPTION
## File Formatting
**Default File Formatting Change:**
Modify the default file formatting to filter out the first slash in the file path.
- If you want the previous output, use the `--full-path` option

### New File Format Options
- `--full-path` : Displays the full file path, including the first slash
- `--no-file-ext` or `-x` : Remove the extension at the end of the file path
- `--filename` or `-f` : Remove all directories from the path, leaving the file name and extension

**Notes:**
- You can use `-fx` to combine `--filename` with `--no-file-ext`.
- You can combine `--full-path` with `--no-file-ext`.