### PR TITLE
Release 0.4.6

### DIFF
--- a/.changelists/sort.xml
+++ b/.changelists/sort.xml
@@ -8,6 +8,11 @@
         <files path_start="changelist_foci" />
         <files file_ext="py" />
     </changelist>
+    <changelist name="Test Fixtures &amp; Data Providers" module="module">
+        <files first_dir="test" />
+        <files filename_prefix="conftest" />
+        <files file_ext="py" />
+    </changelist>
     <changelist name="Test Input Package" module="module">
         <files path_start="test/changelist_foci/input" />
         <files file_ext="py" />

--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v3.1-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@cf654f54962bafc7152d15da33e1015d8e913e2a # v3.2.7
         with:
           inputs: >-
             ./dist/*.tar.gz
@@ -52,7 +52,6 @@ jobs:
           cd ../
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           print-hash: true
-

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ If the changelist name is not provided:
 **All Changes FOCI:** `-a` or `--all-changes`
 An optional flag that overrides Changelist Name and prints out all Changelists with Changes.
 
+**FOCI Comments:** `-c` or `--comments`
+Insert the FOCI into the Changelist Data file comments, rather than printing.
+- This argument is combined with the `--all-changes` argument. All Changelist Comments are updated every time.
+- Disables the `--changelist` name selection argument.
+- Works with both Workspace and Changelist data files.
+
 ## File Format Flags
 **Full Path:** `--full-path`
 The full path of the file is given in Line Subjects.

--- a/changelist_foci/__init__.py
+++ b/changelist_foci/__init__.py
@@ -56,9 +56,9 @@ def generate_changelist_foci(
     foci_format: FormatOptions = DEFAULT_FORMAT_OPTIONS,
 ) -> Generator[str, None, None]:
     """ Generate String Blocks of FOCI.
-- By default, all_changelists argument is True.
-- Changelist_name is matched at the start of the string.
-- If no changelist_name, tries the Default, then the first Changelist.
+ - By default, all_changelists argument is True.
+ - Changelist_name is matched at the start of the string.
+ - If no changelist_name, tries the Default, then the first Changelist.
 
 **Parameters:**
  - changelists (Iterable[Changelist]): The source collection of Changelists to filter and generate from.
@@ -71,13 +71,14 @@ def generate_changelist_foci(
     """
     for cl in changelists:
         yield generate_foci(cl, foci_format)
-        
-        
+
+
 def insert_foci_comments(
     cl_data_storage: ChangelistDataStorage,
     foci_format: FormatOptions,
 ):
-    """ Insert the FOCI into the Changelist Data file comments.
+    """ Insert FOCI into Changelist Data Storage object.
+ - Does not write to the Data file, only updates in-memory data.
 
 **Parameters:**
  - cl_data_storage (ChangelistDataStorage): The Changelist Data Storage access object.

--- a/changelist_foci/__init__.py
+++ b/changelist_foci/__init__.py
@@ -21,7 +21,7 @@ def get_changelist_foci(
  str - The FOCI formatted output.
     """
     # Select Changelist by Name
-    if (cl_name := input_data.changelist_name) not in ["None", None]:   #todo: Remove the String "None", Next Jump Release.
+    if (cl_name := input_data.changelist_name) not in ["None", None]: #todo: Remove the String "None", Next Jump Release.
         try:
             return generate_foci(
                 changelist=filter(lambda x: x.name.startswith(cl_name), input_data.changelists).__next__(),
@@ -31,15 +31,21 @@ def get_changelist_foci(
             exit(f"Specified Changelist {cl_name} not present.")
     # All Changelists, separated by newlines
     elif input_data.all_changes:
-        return '\n\n'.join(
+        # Check the length of the output before 
+        if 0 == len(output_foci := '\n\n'.join(
             generate_changelist_foci(
                 filter(lambda x: len(x.changes) > 0, input_data.changelists),
                 input_data.format_options,
             )
-        )
+        )):
+            exit("There are no Changelists.") 
+        return output_foci
     else: # The Default Changelist
+        # Handle case where there are no changelists
+        if (default_cl := get_default_cl(input_data.changelists)) is None:
+            exit("There are no Changelists.")
         return generate_foci(
-            changelist=get_default_cl(input_data.changelists),
+            changelist=default_cl,
             format_options=input_data.format_options
         )
 

--- a/changelist_foci/__init__.py
+++ b/changelist_foci/__init__.py
@@ -2,8 +2,8 @@
 """
 from typing import Generator, Iterable
 
-from changelist_data import ChangelistDataStorage
 from changelist_data.changelist import Changelist, get_default_cl
+from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
 
 from changelist_foci.foci_writer import generate_foci
 from changelist_foci.format_options import FormatOptions, DEFAULT_FORMAT_OPTIONS

--- a/changelist_foci/__init__.py
+++ b/changelist_foci/__init__.py
@@ -2,6 +2,7 @@
 """
 from typing import Generator, Iterable
 
+from changelist_data import ChangelistDataStorage
 from changelist_data.changelist import Changelist, get_default_cl
 
 from changelist_foci.foci_writer import generate_foci
@@ -70,3 +71,32 @@ def generate_changelist_foci(
     """
     for cl in changelists:
         yield generate_foci(cl, foci_format)
+        
+        
+def insert_foci_comments(
+    cl_data_storage: ChangelistDataStorage,
+    foci_format: FormatOptions,
+):
+    """ Insert the FOCI into the Changelist Data file comments.
+
+**Parameters:**
+ - cl_data_storage (ChangelistDataStorage): The Changelist Data Storage access object.
+ - foci_format (FormatOptions): The Formatting options for the FOCI.
+    """
+    cl_data_storage.update_changelists(
+        Changelist(
+            id=cl.id,
+            name=cl.name,
+            changes=cl.changes,
+            comment=_only_update_comment_if_nonempty(cl, foci_format),
+            is_default=cl.is_default,
+        ) for cl in cl_data_storage.get_changelists()
+    )
+
+
+def _only_update_comment_if_nonempty(
+    cl: Changelist,
+    foci_format: FormatOptions,
+) -> str:
+    updated_comment: str = generate_foci(cl, foci_format)
+    return updated_comment if len(updated_comment) > 0 else cl.comment

--- a/changelist_foci/__main__.py
+++ b/changelist_foci/__main__.py
@@ -2,11 +2,18 @@
 
 
 def main():
-    import changelist_foci
     from sys import argv
+    import changelist_foci
     input_data = changelist_foci.input.validate_input(argv[1:])
-    output_data = changelist_foci.get_changelist_foci(input_data)
-    print(output_data)
+    if not input_data.changelist_data_storage:
+        output_data = changelist_foci.get_changelist_foci(input_data)
+        print(output_data)
+    else:
+        changelist_foci.insert_foci_comments(
+            input_data.changelist_data_storage,
+            input_data.format_options
+        )
+        input_data.changelist_data_storage.write_to_storage()
 
 
 if __name__ == "__main__":

--- a/changelist_foci/__main__.py
+++ b/changelist_foci/__main__.py
@@ -2,13 +2,12 @@
 
 
 def main():
-    from sys import argv
     import changelist_foci
-    input_data = changelist_foci.input.validate_input(argv[1:])
-    if not input_data.changelist_data_storage:
-        output_data = changelist_foci.get_changelist_foci(input_data)
-        print(output_data)
-    else:
+    from sys import argv
+    # When CL-Data-Storage Field is None, print FOCI
+    if not (input_data := changelist_foci.input.validate_input(argv[1:])).changelist_data_storage:
+        print(changelist_foci.get_changelist_foci(input_data))
+    else: # Insert FOCI into Storage
         changelist_foci.insert_foci_comments(
             input_data.changelist_data_storage,
             input_data.format_options

--- a/changelist_foci/input/__init__.py
+++ b/changelist_foci/input/__init__.py
@@ -34,6 +34,7 @@ def validate_input(
         changelist_name=arg_data.changelist_name,
         format_options=_extract_format_options(arg_data),
         all_changes=arg_data.all_changes,
+        comment=arg_data.comment,
     )
 
 

--- a/changelist_foci/input/__init__.py
+++ b/changelist_foci/input/__init__.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from sys import exit
 
-from changelist_data import storage, ChangelistDataStorage
+from changelist_data import storage
 
 from changelist_foci.format_options import FormatOptions
 from changelist_foci.input.argument_data import ArgumentData
@@ -39,7 +39,7 @@ def validate_input(
 def _load_storage(
     changelists_file: str | None,
     workspace_file: str | None,
-) -> ChangelistDataStorage:
+) -> storage.ChangelistDataStorage:
     """ Load the Changelist Data Storage access object.
 
 **Parameters:**

--- a/changelist_foci/input/__init__.py
+++ b/changelist_foci/input/__init__.py
@@ -2,10 +2,8 @@
 """
 from pathlib import Path
 from sys import exit
-from typing import Generator
 
-from changelist_data import storage
-from changelist_data.changelist import Changelist
+from changelist_data import storage, ChangelistDataStorage
 
 from changelist_foci.format_options import FormatOptions
 from changelist_foci.input.argument_data import ArgumentData
@@ -30,43 +28,41 @@ def validate_input(
     """
     arg_data = parse_arguments(arguments)
     return InputData(
-        changelists=_read_storage_file(arg_data.changelists_path, arg_data.workspace_path),
+        changelists=(cl_data_storage := _load_storage(arg_data.changelists_path, arg_data.workspace_path)).generate_changelists(),
         changelist_name=arg_data.changelist_name,
         format_options=_extract_format_options(arg_data),
         all_changes=arg_data.all_changes,
-        comment=arg_data.comment,
+        changelist_data_storage=cl_data_storage if arg_data.comment else None,
     )
 
 
-def _read_storage_file(
+def _load_storage(
     changelists_file: str | None,
     workspace_file: str | None,
-) -> Generator[Changelist, None, None]:
-    """ Process the Given File Arguments, and read from Storage.
- - Storage is managed by changelist_data package.
+) -> ChangelistDataStorage:
+    """ Load the Changelist Data Storage access object.
 
 **Parameters:**
- - changelists_file (str | None): A string path to the Changelists file, if specified.
- - workspace_file (str | None): A string path to the Workspace file, if specified.
+ - changelists_file (str?): A string path to the Changelists file, if specified.
+ - workspace_file (str?): A string path to the Workspace file, if specified.
 
-**Yields:**
- Changelist - The Changelist data from the storage file.
+**Returns:**
+ ChangelistDataStorage - The Data Storage Access object.
     """
     if isinstance(changelists_file, str) and isinstance(workspace_file, str):
         exit("Cannot use two Data Files!")
     if validate_name(changelists_file):
-        yield from storage.generate_changelists_from_storage(
+        return storage.load_storage(
             storage.storage_type.StorageType.CHANGELISTS,
             Path(changelists_file)
         )
     elif validate_name(workspace_file):
-        yield from storage.generate_changelists_from_storage(
+        return storage.load_storage(
             storage.storage_type.StorageType.WORKSPACE,
             Path(workspace_file)
         )
     else:
-        yield from storage.generate_changelists_from_storage()
-    return None
+        return storage.load_storage()
 
 
 def _extract_format_options(

--- a/changelist_foci/input/argument_data.py
+++ b/changelist_foci/input/argument_data.py
@@ -19,7 +19,7 @@ class ArgumentData:
  - no_file_ext (bool): Remove the File Extension.
  - filename (bool): Remove the Parent Directories.
  - all_changes (bool): Format and Print all Changes from all Changelists.
- - 
+ - comment (bool): Whether to insert FOCI into the Changelist Comments, rather than printing.
     """
     changelist_name: str | None = None
     changelists_path: str | None = None
@@ -28,4 +28,4 @@ class ArgumentData:
     no_file_ext: bool = False
     filename: bool = False
     all_changes: bool = False
-    #
+    comment: bool = False

--- a/changelist_foci/input/argument_data.py
+++ b/changelist_foci/input/argument_data.py
@@ -19,6 +19,7 @@ class ArgumentData:
  - no_file_ext (bool): Remove the File Extension.
  - filename (bool): Remove the Parent Directories.
  - all_changes (bool): Format and Print all Changes from all Changelists.
+ - 
     """
     changelist_name: str | None = None
     changelists_path: str | None = None
@@ -27,3 +28,4 @@ class ArgumentData:
     no_file_ext: bool = False
     filename: bool = False
     all_changes: bool = False
+    #

--- a/changelist_foci/input/argument_parser.py
+++ b/changelist_foci/input/argument_parser.py
@@ -62,7 +62,8 @@ def _validate_arguments(
         full_path=parsed_args.full_path,
         no_file_ext=parsed_args.no_file_ext,
         filename=parsed_args.filename,
-        all_changes=parsed_args.all_changes
+        all_changes=parsed_args.all_changes,
+        comment=parsed_args.comment,
     )
 
 
@@ -117,15 +118,15 @@ def _define_arguments() -> ArgumentParser:
         help='Remove Parent Directories from File paths.',
     )
     parser.add_argument(
-        '--', '-',
-        action='store_true',
-        default=False,
-        help='.',
-    )
-    parser.add_argument(
         '--all-changes', '-a',
         action='store_true',
         default=False,
         help='Output All Changes in any Changelist.',
+    )
+    parser.add_argument(
+        '--comment', '-c',
+        action='store_true',
+        default=False,
+        help='Insert FOCI into Changelist Workspace Comments instead of printing.',
     )
     return parser

--- a/changelist_foci/input/argument_parser.py
+++ b/changelist_foci/input/argument_parser.py
@@ -117,6 +117,12 @@ def _define_arguments() -> ArgumentParser:
         help='Remove Parent Directories from File paths.',
     )
     parser.add_argument(
+        '--', '-',
+        action='store_true',
+        default=False,
+        help='.',
+    )
+    parser.add_argument(
         '--all-changes', '-a',
         action='store_true',
         default=False,

--- a/changelist_foci/input/input_data.py
+++ b/changelist_foci/input/input_data.py
@@ -17,10 +17,10 @@ class InputData:
  - changelist_name (str): The name of the Changelist, or None.
  - format_options (FormatOptions): The options for output formatting.
  - all_changes (bool): Flag for printing all changes in any Changelist.
- - 
+ - comment (bool): Insert FOCI into Changelist Comments instead of printing.
     """
     changelists: Iterable[Changelist]
     changelist_name: str | None = None
     format_options: FormatOptions = DEFAULT_FORMAT_OPTIONS
     all_changes: bool = False
-    #
+    comment: bool = False

--- a/changelist_foci/input/input_data.py
+++ b/changelist_foci/input/input_data.py
@@ -17,8 +17,10 @@ class InputData:
  - changelist_name (str): The name of the Changelist, or None.
  - format_options (FormatOptions): The options for output formatting.
  - all_changes (bool): Flag for printing all changes in any Changelist.
+ - 
     """
     changelists: Iterable[Changelist]
     changelist_name: str | None = None
     format_options: FormatOptions = DEFAULT_FORMAT_OPTIONS
     all_changes: bool = False
+    #

--- a/changelist_foci/input/input_data.py
+++ b/changelist_foci/input/input_data.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Iterable
 
+from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
 from changelist_data.changelist import Changelist
 
 from changelist_foci.format_options import FormatOptions, DEFAULT_FORMAT_OPTIONS
@@ -17,10 +18,10 @@ class InputData:
  - changelist_name (str): The name of the Changelist, or None.
  - format_options (FormatOptions): The options for output formatting.
  - all_changes (bool): Flag for printing all changes in any Changelist.
- - comment (bool): Insert FOCI into Changelist Comments instead of printing.
+ - changelist_data_storage (ChangelistDataStorage): If this field is present, insert FOCI into Changelist Comments instead of printing.
     """
     changelists: Iterable[Changelist]
     changelist_name: str | None = None
     format_options: FormatOptions = DEFAULT_FORMAT_OPTIONS
     all_changes: bool = False
-    comment: bool = False
+    changelist_data_storage: ChangelistDataStorage | None = None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="changelist-foci",
-    version="0.4.5",
+    version="0.4.6",
 	description='Changelist FOCI',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/changelist_foci/conftest.py
+++ b/test/changelist_foci/conftest.py
@@ -41,6 +41,15 @@ def get_simple_changelist_xml() -> str:
 </project>"""
 
 
+def get_simple_changelist_data_xml() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<changelists>
+  <list id="9f60fda2-421e-4a4b-bd0f-4c8f83a47c88" name="Simple" comment="Main Program Files">
+    <change beforePath="/main.py" beforeDir="false"  afterPath="/main.py" afterDir="false" />
+  </list>
+</changelists>"""
+
+
 def get_multi_changelist_xml() -> str:
     return """<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">

--- a/test/changelist_foci/conftest.py
+++ b/test/changelist_foci/conftest.py
@@ -2,10 +2,16 @@
 """
 import os
 import tempfile
+from pathlib import Path
 
+import changelist_data
 import pytest
 from changelist_data.changelist import Changelist
 from changelist_data.file_change import FileChange
+
+
+CHANGELIST_DATA_FILE_PATH = Path(changelist_data.storage.file_validation.CHANGELISTS_FILE_PATH_STR)
+WORKSPACE_DATA_FILE_PATH = Path(changelist_data.storage.file_validation.WORKSPACE_FILE_PATH_STR)
 
 
 def get_empty_xml() -> str:
@@ -163,3 +169,79 @@ class FileOutputCollector:
     
     def get_output(self) -> str:
         return self._output_str
+
+
+class PrintCollector:  # Author: DK96-OS
+    def __init__(self):
+        self.collection: str = ''
+
+    def get_output(self) -> str:
+        return self.collection
+
+    def append_print_output(self, output: str):
+        self.collection = self.collection + output
+
+    def assert_expected(self, expected: str):
+        assert self.collection == expected
+
+    def get_mock_print(self):
+        def _collection(result, **kwargs):
+            self.append_print_output(result)
+        return _collection
+    
+
+CHANGELIST_DATA_SAMPLE_1 = """<?xml version='1.0' encoding='utf-8'?>
+<changelists>
+  <list id="c24cb1b3-d9d4-efe1-6d77-2f270a94f8c0" name="CL-FOCI Input Package" comment="">
+    <change beforePath="/changelist_foci/input/input_data.py" beforeDir="false" afterPath="/changelist_foci/input/input_data.py" afterDir="false" />
+    <change beforePath="/changelist_foci/input/argument_parser.py" beforeDir="false" afterPath="/changelist_foci/input/argument_parser.py" afterDir="false" />
+    <change beforePath="/changelist_foci/input/argument_data.py" beforeDir="false" afterPath="/changelist_foci/input/argument_data.py" afterDir="false" />
+    <change beforePath="/changelist_foci/input/__init__.py" beforeDir="false" afterPath="/changelist_foci/input/__init__.py" afterDir="false" />
+  </list>
+  <list id="b17e81ed-e7e9-ae8e-a184-bffc91c68445" name="CL-FOCI Main Package" comment="">
+    <change beforePath="/changelist_foci/__init__.py" beforeDir="false" afterPath="/changelist_foci/__init__.py" afterDir="false" />
+  </list>
+  <list id="79474592-699f-0d51-bba8-4b6dd33537f7" name="Test Fixtures &amp; Data Providers" comment="">
+    <change beforePath="/test/changelist_foci/conftest.py" beforeDir="false" afterPath="/test/changelist_foci/conftest.py" afterDir="false" />
+  </list>
+  <list id="fa3e75da-9391-3e89-3446-a71cdfe6ae37" name="Test Input Package" comment="">
+    <change beforePath="/test/changelist_foci/input/test_method_validate_input.py" beforeDir="false" afterPath="/test/changelist_foci/input/test_method_validate_input.py" afterDir="false" />
+    <change beforePath="/test/changelist_foci/input/test_argument_parser.py" beforeDir="false" afterPath="/test/changelist_foci/input/test_argument_parser.py" afterDir="false" />
+  </list>
+  <list id="e0d0366d-a5bd-0beb-3371-83affb120d85" name="Test Main Package" comment="">
+    <change beforePath="/test/changelist_foci/test_main.py" beforeDir="false" afterPath="/test/changelist_foci/test_main.py" afterDir="false" />
+  </list>
+</changelists>"""
+
+WORKSPACE_DATA_SAMPLE_1 = """<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="d08b98d0-78b5-88de-fa66-5b7e2c55ff33" name="CL-FOCI Input Package" comment="CL-FOCI Input Package">
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/__init__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/argument_data.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/argument_data.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/argument_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/argument_parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/input_data.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/input_data.py" afterDir="false" />
+    </list>
+    <list id="0dad9b9d-959c-81d1-9ff9-9fc65ecfa784" name="Changelists Config" comment="">
+      <change beforePath="$PROJECT_DIR$/.changelists/sort.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.changelists/sort.xml" afterDir="false" />
+    </list>
+    <list id="99c5423e-e3b0-f07b-2b92-0e5c86792a2c" name="Test Fixtures &amp; Data Providers" comment="">
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/conftest.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/conftest.py" afterDir="false" />
+    </list>
+    <list id="7a5f5562-3c5a-0e6e-d299-ab2c54fa9a3e" name="Test Input Package" comment="">
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/input/test_argument_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/input/test_argument_parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" afterDir="false" />
+    </list>
+    <list id="09965131-41f7-e136-a847-fba638ebeb47" name="Test Main Package" comment="">
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/test_main.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/test_main.py" afterDir="false" />
+    </list>
+    <file path="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" ignored="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+</project>"""

--- a/test/changelist_foci/conftest.py
+++ b/test/changelist_foci/conftest.py
@@ -116,7 +116,6 @@ def get_main_changelist_data() -> Changelist:
     )
 
 
-
 REL_FILE_PATH_1 = 'main_package/__main__.py'
 REL_FILE_PATH_2 = 'main_package/__init__.py'
 
@@ -148,3 +147,19 @@ def temp_cwd():
     yield tdir
     os.chdir(initial_cwd)
     tdir.cleanup()
+    
+
+class FileOutputCollector:
+    """ Author: DK96-OS 2025
+    """
+    def __init__(self):
+        self._output_str = ''
+    
+    def set_output(self, output_str: str, **kwargs):
+        self._output_str = output_str
+    
+    def get_mock_write_text(self):
+        return self.set_output
+    
+    def get_output(self) -> str:
+        return self._output_str

--- a/test/changelist_foci/conftest.py
+++ b/test/changelist_foci/conftest.py
@@ -180,7 +180,9 @@ class FileOutputCollector:
         return self._output_str
 
 
-class PrintCollector:  # Author: DK96-OS
+class PrintCollector:
+    """ Author: DK96-OS 2025
+    """
     def __init__(self):
         self.collection: str = ''
 

--- a/test/changelist_foci/input/test_argument_parser.py
+++ b/test/changelist_foci/input/test_argument_parser.py
@@ -1,4 +1,4 @@
-"""Testing Argument Parser Methods.
+""" Testing Argument Parser Methods.
 """
 import pytest
 
@@ -96,13 +96,35 @@ def test_parse_arguments_all_changes_returns_data():
     assert result.all_changes
 
 
-def test_parse_arguments_comment_returns_data():
+def test_parse_arguments_c_returns_data():
     result = parse_arguments(['-c'])
     assert result.changelist_name is None
     assert result.workspace_path is None
     assert not result.full_path
     assert not result.no_file_ext
     assert not result.filename
+    assert not result.all_changes
+    assert result.comment
+
+
+def test_parse_arguments_comment_returns_data():
+    result = parse_arguments(['--comment'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert not result.no_file_ext
+    assert not result.filename
+    assert not result.all_changes
+    assert result.comment
+
+
+def test_parse_arguments_cfx_returns_data():
+    result = parse_arguments(['-cfx'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert result.no_file_ext
+    assert result.filename
     assert not result.all_changes
     assert result.comment
 

--- a/test/changelist_foci/input/test_argument_parser.py
+++ b/test/changelist_foci/input/test_argument_parser.py
@@ -96,6 +96,16 @@ def test_parse_arguments_all_changes_returns_data():
     assert result.all_changes
 
 
+def test_parse_arguments__returns_data():
+    result = parse_arguments(['--'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert not result.no_file_ext
+    assert not result.filename
+    assert result.all_changes
+
+
 def test_parse_arguments_all_changes_plus_filename_returns_data():
     result = parse_arguments(['-af'])
     assert result.changelist_name is None
@@ -128,27 +138,15 @@ def test_parse_arguments_all_changes_with_changelist_name_returns_data():
 
 
 def test_parse_arguments_changelist_argument_missing_raises_exit():
-    try:
+    with pytest.raises(SystemExit):
         parse_arguments(['--changelist', '-a', 'Main'])
-        raised_exit = False
-    except SystemExit:
-        raised_exit = True
-    assert raised_exit
 
 
 def test_parse_arguments_changelist_file_argument_blank_raises_exit():
-    try:
+    with pytest.raises(SystemExit):
         parse_arguments(['--changelists_file', ''])
-        raised_exit = False
-    except SystemExit:
-        raised_exit = True
-    assert raised_exit
 
 
 def test_parse_arguments_workspace_file_argument_blank_raises_exit():
-    try:
+    with pytest.raises(SystemExit):
         parse_arguments(['--workspace_file', ''])
-        raised_exit = False
-    except SystemExit:
-        raised_exit = True
-    assert raised_exit

--- a/test/changelist_foci/input/test_argument_parser.py
+++ b/test/changelist_foci/input/test_argument_parser.py
@@ -129,6 +129,17 @@ def test_parse_arguments_cfx_returns_data():
     assert result.comment
 
 
+def test_parse_arguments_acfx_returns_data():
+    result = parse_arguments(['-acfx'])
+    assert result.changelist_name is None
+    assert result.workspace_path is None
+    assert not result.full_path
+    assert result.no_file_ext
+    assert result.filename
+    assert result.all_changes
+    assert result.comment
+
+
 def test_parse_arguments_all_changes_plus_filename_returns_data():
     result = parse_arguments(['-af'])
     assert result.changelist_name is None

--- a/test/changelist_foci/input/test_argument_parser.py
+++ b/test/changelist_foci/input/test_argument_parser.py
@@ -96,14 +96,15 @@ def test_parse_arguments_all_changes_returns_data():
     assert result.all_changes
 
 
-def test_parse_arguments__returns_data():
-    result = parse_arguments(['--'])
+def test_parse_arguments_comment_returns_data():
+    result = parse_arguments(['-c'])
     assert result.changelist_name is None
     assert result.workspace_path is None
     assert not result.full_path
     assert not result.no_file_ext
     assert not result.filename
-    assert result.all_changes
+    assert not result.all_changes
+    assert result.comment
 
 
 def test_parse_arguments_all_changes_plus_filename_returns_data():

--- a/test/changelist_foci/input/test_method_validate_input.py
+++ b/test/changelist_foci/input/test_method_validate_input.py
@@ -86,7 +86,7 @@ def test_validate_input_comment_returns_data():
         assert result.format_options == FormatOptions(
             False, False, False
         )
-        assert result.comment
+        assert result.changelist_data_storage
 
 
 def test_validate_input_filename_only_returns_data():
@@ -106,7 +106,7 @@ def test_validate_input_filename_only_returns_data():
         assert result.format_options == FormatOptions(
             False, True, True
         )
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_file_does_not_exist_raises_exit():
@@ -117,7 +117,7 @@ def test_validate_input_file_does_not_exist_raises_exit():
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 0
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_both_changelist_and_workspace_args_provided_raises_exit():
@@ -143,7 +143,7 @@ def test_validate_input_workspace_file_provided():
         assert result.changelist_name is None
         assert 1 == len(list(result.changelists))
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_changelist_file_valid_no_changelists(empty_changelists_xml):
@@ -159,7 +159,7 @@ def test_validate_input_changelist_file_valid_no_changelists(empty_changelists_x
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 0
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_changelist_file_simple(simple_changelists_xml):
@@ -175,7 +175,7 @@ def test_validate_input_changelist_file_simple(simple_changelists_xml):
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 1
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_changelist_file_multi(multi_changelists_xml):
@@ -191,7 +191,7 @@ def test_validate_input_changelist_file_multi(multi_changelists_xml):
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 2
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_changelist_file_multi_name_argument(multi_changelists_xml):
@@ -207,7 +207,7 @@ def test_validate_input_changelist_file_multi_name_argument(multi_changelists_xm
         assert result.changelist_name == 'Main'
         assert len(list(result.changelists)) == 2
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage
 
 
 def test_validate_input_changelist_file_invalid(invalid_changelists_xml):
@@ -223,4 +223,4 @@ def test_validate_input_changelist_file_invalid(invalid_changelists_xml):
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 0
         assert result.format_options == DEFAULT_FORMAT_OPTIONS
-        assert not result.comment
+        assert not result.changelist_data_storage

--- a/test/changelist_foci/input/test_method_validate_input.py
+++ b/test/changelist_foci/input/test_method_validate_input.py
@@ -5,9 +5,9 @@ from unittest.mock import Mock
 
 import pytest
 
-from changelist_foci.format_options import FormatOptions
+from changelist_foci.format_options import FormatOptions, DEFAULT_FORMAT_OPTIONS
 from changelist_foci.input import validate_input
-from test.changelist_foci.conftest import get_simple_changelist_xml
+from test.changelist_foci.conftest import get_simple_changelist_xml, FileOutputCollector
 
 
 def test_validate_input_empty_args_returns_data():
@@ -67,8 +67,9 @@ def test_validate_input_full_path_returns_data():
         )
 
 
-def test_validate_input__returns_data():
-    test_input = ['--']
+def test_validate_input_comment_returns_data():
+    test_input = ['-c']
+    output_collector = FileOutputCollector()
     with pytest.MonkeyPatch().context() as c:
         c.setattr(Path, 'exists', lambda x: x.name == 'workspace.xml')
         c.setattr(Path, 'is_file', lambda _: True)
@@ -76,14 +77,16 @@ def test_validate_input__returns_data():
         obj.__dict__["st_size"] = 4 * 1024
         c.setattr(Path, 'stat', lambda _: obj)
         c.setattr(Path, 'read_text', lambda _: get_simple_changelist_xml())
+        c.setattr(Path, 'write_text', output_collector.get_mock_write_text())
         #
         result = validate_input(test_input)
         assert not result.all_changes
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 1
         assert result.format_options == FormatOptions(
-            True, False, False
+            False, False, False
         )
+        assert result.comment
 
 
 def test_validate_input_filename_only_returns_data():
@@ -103,6 +106,7 @@ def test_validate_input_filename_only_returns_data():
         assert result.format_options == FormatOptions(
             False, True, True
         )
+        assert not result.comment
 
 
 def test_validate_input_file_does_not_exist_raises_exit():
@@ -112,6 +116,8 @@ def test_validate_input_file_does_not_exist_raises_exit():
         result = validate_input(test_input)
         assert result.changelist_name is None
         assert len(list(result.changelists)) == 0
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment
 
 
 def test_validate_input_both_changelist_and_workspace_args_provided_raises_exit():
@@ -119,7 +125,7 @@ def test_validate_input_both_changelist_and_workspace_args_provided_raises_exit(
         result = validate_input([
             '--changelists_file', 'data.xml', '--workspace_file', 'workspace.xml'
         ])
-        list(result.changelists)
+        list(result.changelists) # Runs Generator
 
 
 def test_validate_input_workspace_file_provided():
@@ -134,7 +140,10 @@ def test_validate_input_workspace_file_provided():
         result = validate_input([
             '--workspace_file', 'workspace.xml'
         ])
-        list(result.changelists)
+        assert result.changelist_name is None
+        assert 1 == len(list(result.changelists))
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment
 
 
 def test_validate_input_changelist_file_valid_no_changelists(empty_changelists_xml):
@@ -147,7 +156,10 @@ def test_validate_input_changelist_file_valid_no_changelists(empty_changelists_x
         c.setattr(Path, 'read_text', lambda _: empty_changelists_xml)
         #
         result = validate_input(['--changelists_file', 'data.xml'])
+        assert result.changelist_name is None
         assert len(list(result.changelists)) == 0
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment
 
 
 def test_validate_input_changelist_file_simple(simple_changelists_xml):
@@ -160,7 +172,10 @@ def test_validate_input_changelist_file_simple(simple_changelists_xml):
         c.setattr(Path, 'read_text', lambda _: simple_changelists_xml)
         #
         result = validate_input(['--changelists_file', 'data.xml'])
+        assert result.changelist_name is None
         assert len(list(result.changelists)) == 1
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment
 
 
 def test_validate_input_changelist_file_multi(multi_changelists_xml):
@@ -173,7 +188,26 @@ def test_validate_input_changelist_file_multi(multi_changelists_xml):
         c.setattr(Path, 'read_text', lambda _: multi_changelists_xml)
         #
         result = validate_input(['--changelists_file', 'data.xml'])
+        assert result.changelist_name is None
         assert len(list(result.changelists)) == 2
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment
+
+
+def test_validate_input_changelist_file_multi_name_argument(multi_changelists_xml):
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda x: x.name == 'data.xml')
+        c.setattr(Path, 'is_file', lambda _: True)
+        obj = Mock()
+        obj.__dict__["st_size"] = 4 * 1024
+        c.setattr(Path, 'stat', lambda _: obj)
+        c.setattr(Path, 'read_text', lambda _: multi_changelists_xml)
+        #
+        result = validate_input(['--changelists_file', 'data.xml', '--changelist', 'Main'])
+        assert result.changelist_name == 'Main'
+        assert len(list(result.changelists)) == 2
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment
 
 
 def test_validate_input_changelist_file_invalid(invalid_changelists_xml):
@@ -186,4 +220,7 @@ def test_validate_input_changelist_file_invalid(invalid_changelists_xml):
         c.setattr(Path, 'read_text', lambda _: invalid_changelists_xml)
         #
         result = validate_input(['--changelists_file', 'data.xml'])
+        assert result.changelist_name is None
         assert len(list(result.changelists)) == 0
+        assert result.format_options == DEFAULT_FORMAT_OPTIONS
+        assert not result.comment

--- a/test/changelist_foci/input/test_method_validate_input.py
+++ b/test/changelist_foci/input/test_method_validate_input.py
@@ -67,6 +67,25 @@ def test_validate_input_full_path_returns_data():
         )
 
 
+def test_validate_input__returns_data():
+    test_input = ['--']
+    with pytest.MonkeyPatch().context() as c:
+        c.setattr(Path, 'exists', lambda x: x.name == 'workspace.xml')
+        c.setattr(Path, 'is_file', lambda _: True)
+        obj = Mock()
+        obj.__dict__["st_size"] = 4 * 1024
+        c.setattr(Path, 'stat', lambda _: obj)
+        c.setattr(Path, 'read_text', lambda _: get_simple_changelist_xml())
+        #
+        result = validate_input(test_input)
+        assert not result.all_changes
+        assert result.changelist_name is None
+        assert len(list(result.changelists)) == 1
+        assert result.format_options == FormatOptions(
+            True, False, False
+        )
+
+
 def test_validate_input_filename_only_returns_data():
     test_input = ['-fx']
     with pytest.MonkeyPatch().context() as c:

--- a/test/changelist_foci/test_main.py
+++ b/test/changelist_foci/test_main.py
@@ -2,92 +2,12 @@
 """
 import builtins
 import sys
-from pathlib import Path
 
-import changelist_data
 import pytest
 
 from changelist_foci.__main__ import main
-
-
-class PrintCollector:  # Author: DK96-OS
-    def __init__(self):
-        self.collection: str = ''
-
-    def get_output(self) -> str:
-        return self.collection
-
-    def append_print_output(self, output: str):
-        self.collection = self.collection + output
-
-    def assert_expected(self, expected: str):
-        assert self.collection == expected
-
-    def get_mock_print(self):
-        def _collection(result, **kwargs):
-            self.append_print_output(result)
-        return _collection
-
-
-CHANGELIST_DATA_FILE_PATH = Path(changelist_data.storage.file_validation.CHANGELISTS_FILE_PATH_STR)
-WORKSPACE_DATA_FILE_PATH = Path(changelist_data.storage.file_validation.WORKSPACE_FILE_PATH_STR)
-
-CHANGELIST_DATA_SAMPLE_1 = """<?xml version='1.0' encoding='utf-8'?>
-<changelists>
-  <list id="c24cb1b3-d9d4-efe1-6d77-2f270a94f8c0" name="CL-FOCI Input Package" comment="">
-    <change beforePath="/changelist_foci/input/input_data.py" beforeDir="false" afterPath="/changelist_foci/input/input_data.py" afterDir="false" />
-    <change beforePath="/changelist_foci/input/argument_parser.py" beforeDir="false" afterPath="/changelist_foci/input/argument_parser.py" afterDir="false" />
-    <change beforePath="/changelist_foci/input/argument_data.py" beforeDir="false" afterPath="/changelist_foci/input/argument_data.py" afterDir="false" />
-    <change beforePath="/changelist_foci/input/__init__.py" beforeDir="false" afterPath="/changelist_foci/input/__init__.py" afterDir="false" />
-  </list>
-  <list id="b17e81ed-e7e9-ae8e-a184-bffc91c68445" name="CL-FOCI Main Package" comment="">
-    <change beforePath="/changelist_foci/__init__.py" beforeDir="false" afterPath="/changelist_foci/__init__.py" afterDir="false" />
-  </list>
-  <list id="79474592-699f-0d51-bba8-4b6dd33537f7" name="Test Fixtures &amp; Data Providers" comment="">
-    <change beforePath="/test/changelist_foci/conftest.py" beforeDir="false" afterPath="/test/changelist_foci/conftest.py" afterDir="false" />
-  </list>
-  <list id="fa3e75da-9391-3e89-3446-a71cdfe6ae37" name="Test Input Package" comment="">
-    <change beforePath="/test/changelist_foci/input/test_method_validate_input.py" beforeDir="false" afterPath="/test/changelist_foci/input/test_method_validate_input.py" afterDir="false" />
-    <change beforePath="/test/changelist_foci/input/test_argument_parser.py" beforeDir="false" afterPath="/test/changelist_foci/input/test_argument_parser.py" afterDir="false" />
-  </list>
-  <list id="e0d0366d-a5bd-0beb-3371-83affb120d85" name="Test Main Package" comment="">
-    <change beforePath="/test/changelist_foci/test_main.py" beforeDir="false" afterPath="/test/changelist_foci/test_main.py" afterDir="false" />
-  </list>
-</changelists>"""
-
-WORKSPACE_DATA_SAMPLE_1 = """<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="AutoImportSettings">
-    <option name="autoReloadType" value="SELECTIVE" />
-  </component>
-  <component name="ChangeListManager">
-    <list default="true" id="d08b98d0-78b5-88de-fa66-5b7e2c55ff33" name="CL-FOCI Input Package" comment="CL-FOCI Input Package">
-      <change beforePath="$PROJECT_DIR$/changelist_foci/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/__init__.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/changelist_foci/input/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/__init__.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/changelist_foci/input/argument_data.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/argument_data.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/changelist_foci/input/argument_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/argument_parser.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/changelist_foci/input/input_data.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/input_data.py" afterDir="false" />
-    </list>
-    <list id="0dad9b9d-959c-81d1-9ff9-9fc65ecfa784" name="Changelists Config" comment="">
-      <change beforePath="$PROJECT_DIR$/.changelists/sort.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.changelists/sort.xml" afterDir="false" />
-    </list>
-    <list id="99c5423e-e3b0-f07b-2b92-0e5c86792a2c" name="Test Fixtures &amp; Data Providers" comment="">
-      <change beforePath="$PROJECT_DIR$/test/changelist_foci/conftest.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/conftest.py" afterDir="false" />
-    </list>
-    <list id="7a5f5562-3c5a-0e6e-d299-ab2c54fa9a3e" name="Test Input Package" comment="">
-      <change beforePath="$PROJECT_DIR$/test/changelist_foci/input/test_argument_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/input/test_argument_parser.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" afterDir="false" />
-    </list>
-    <list id="09965131-41f7-e136-a847-fba638ebeb47" name="Test Main Package" comment="">
-      <change beforePath="$PROJECT_DIR$/test/changelist_foci/test_main.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/test_main.py" afterDir="false" />
-    </list>
-    <file path="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" ignored="true" />
-    <option name="SHOW_DIALOG" value="false" />
-    <option name="HIGHLIGHT_CONFLICTS" value="true" />
-    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
-    <option name="LAST_RESOLUTION" value="IGNORE" />
-  </component>
-</project>"""
+from test.changelist_foci.conftest import CHANGELIST_DATA_FILE_PATH, PrintCollector, CHANGELIST_DATA_SAMPLE_1, \
+    WORKSPACE_DATA_FILE_PATH, WORKSPACE_DATA_SAMPLE_1
 
 
 def test_main_invalid_arg_raises_exit(temp_cwd):
@@ -314,11 +234,7 @@ def test_main_comment_workspace_sample_1(temp_cwd):
     main()
     # Check the Workspace File for the output
     result = WORKSPACE_DATA_FILE_PATH.read_text()
-    assert """CL-FOCI Input Package:
-* Update changelist_foci/input/input_data.py
-* Update changelist_foci/input/argument_parser.py
-* Update changelist_foci/input/argument_data.py
-* Update changelist_foci/input/__init__.py""" in result
+    assert """CL-FOCI Input Package:&#10;* Update changelist_foci/input/__init__.py&#10;* Update changelist_foci/input/argument_data.py&#10;* Update changelist_foci/input/argument_parser.py&#10;* Update changelist_foci/input/input_data.py""" in result
 
 
 def test_main_comment_changelist_sample_1(temp_cwd):
@@ -327,12 +243,21 @@ def test_main_comment_changelist_sample_1(temp_cwd):
     CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
     CHANGELIST_DATA_FILE_PATH.touch()
     CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
-    
+    #
     main()
     # Check the Changelist Data file for the output
     result = CHANGELIST_DATA_FILE_PATH.read_text()
-    assert """CL-FOCI Input Package:
-* Update changelist_foci/input/input_data.py
-* Update changelist_foci/input/argument_parser.py
-* Update changelist_foci/input/argument_data.py
-* Update changelist_foci/input/__init__.py""" in result
+    assert """CL-FOCI Input Package:&#10;* Update changelist_foci/input/input_data.py&#10;* Update changelist_foci/input/argument_parser.py&#10;* Update changelist_foci/input/argument_data.py&#10;* Update changelist_foci/input/__init__.py""" in result
+
+
+def test_main_comment_fx_changelist_sample_1(temp_cwd):
+    sys.argv = ['cl-foci', '-cfx']
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    # Check the Changelist Data file for the output
+    result = CHANGELIST_DATA_FILE_PATH.read_text()
+    assert """CL-FOCI Input Package:&#10;* Update input_data&#10;* Update argument_parser&#10;* Update argument_data&#10;* Update __init__""" in result

--- a/test/changelist_foci/test_main.py
+++ b/test/changelist_foci/test_main.py
@@ -1,9 +1,93 @@
 """ Testing the Main Module.
 """
+import builtins
 import sys
+from pathlib import Path
+
+import changelist_data
 import pytest
 
 from changelist_foci.__main__ import main
+
+
+class PrintCollector:  # Author: DK96-OS
+    def __init__(self):
+        self.collection: str = ''
+
+    def get_output(self) -> str:
+        return self.collection
+
+    def append_print_output(self, output: str):
+        self.collection = self.collection + output
+
+    def assert_expected(self, expected: str):
+        assert self.collection == expected
+
+    def get_mock_print(self):
+        def _collection(result, **kwargs):
+            self.append_print_output(result)
+        return _collection
+
+
+CHANGELIST_DATA_FILE_PATH = Path(changelist_data.storage.file_validation.CHANGELISTS_FILE_PATH_STR)
+WORKSPACE_DATA_FILE_PATH = Path(changelist_data.storage.file_validation.WORKSPACE_FILE_PATH_STR)
+
+CHANGELIST_DATA_SAMPLE_1 = """<?xml version='1.0' encoding='utf-8'?>
+<changelists>
+  <list id="c24cb1b3-d9d4-efe1-6d77-2f270a94f8c0" name="CL-FOCI Input Package" comment="">
+    <change beforePath="/changelist_foci/input/input_data.py" beforeDir="false" afterPath="/changelist_foci/input/input_data.py" afterDir="false" />
+    <change beforePath="/changelist_foci/input/argument_parser.py" beforeDir="false" afterPath="/changelist_foci/input/argument_parser.py" afterDir="false" />
+    <change beforePath="/changelist_foci/input/argument_data.py" beforeDir="false" afterPath="/changelist_foci/input/argument_data.py" afterDir="false" />
+    <change beforePath="/changelist_foci/input/__init__.py" beforeDir="false" afterPath="/changelist_foci/input/__init__.py" afterDir="false" />
+  </list>
+  <list id="b17e81ed-e7e9-ae8e-a184-bffc91c68445" name="CL-FOCI Main Package" comment="">
+    <change beforePath="/changelist_foci/__init__.py" beforeDir="false" afterPath="/changelist_foci/__init__.py" afterDir="false" />
+  </list>
+  <list id="79474592-699f-0d51-bba8-4b6dd33537f7" name="Test Fixtures &amp; Data Providers" comment="">
+    <change beforePath="/test/changelist_foci/conftest.py" beforeDir="false" afterPath="/test/changelist_foci/conftest.py" afterDir="false" />
+  </list>
+  <list id="fa3e75da-9391-3e89-3446-a71cdfe6ae37" name="Test Input Package" comment="">
+    <change beforePath="/test/changelist_foci/input/test_method_validate_input.py" beforeDir="false" afterPath="/test/changelist_foci/input/test_method_validate_input.py" afterDir="false" />
+    <change beforePath="/test/changelist_foci/input/test_argument_parser.py" beforeDir="false" afterPath="/test/changelist_foci/input/test_argument_parser.py" afterDir="false" />
+  </list>
+  <list id="e0d0366d-a5bd-0beb-3371-83affb120d85" name="Test Main Package" comment="">
+    <change beforePath="/test/changelist_foci/test_main.py" beforeDir="false" afterPath="/test/changelist_foci/test_main.py" afterDir="false" />
+  </list>
+</changelists>"""
+
+WORKSPACE_DATA_SAMPLE_1 = """<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="d08b98d0-78b5-88de-fa66-5b7e2c55ff33" name="CL-FOCI Input Package" comment="CL-FOCI Input Package">
+      <change beforePath="$PROJECT_DIR$/changelist_foci/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/__init__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/__init__.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/argument_data.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/argument_data.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/argument_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/argument_parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/changelist_foci/input/input_data.py" beforeDir="false" afterPath="$PROJECT_DIR$/changelist_foci/input/input_data.py" afterDir="false" />
+    </list>
+    <list id="0dad9b9d-959c-81d1-9ff9-9fc65ecfa784" name="Changelists Config" comment="">
+      <change beforePath="$PROJECT_DIR$/.changelists/sort.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.changelists/sort.xml" afterDir="false" />
+    </list>
+    <list id="99c5423e-e3b0-f07b-2b92-0e5c86792a2c" name="Test Fixtures &amp; Data Providers" comment="">
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/conftest.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/conftest.py" afterDir="false" />
+    </list>
+    <list id="7a5f5562-3c5a-0e6e-d299-ab2c54fa9a3e" name="Test Input Package" comment="">
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/input/test_argument_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/input/test_argument_parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" afterDir="false" />
+    </list>
+    <list id="09965131-41f7-e136-a847-fba638ebeb47" name="Test Main Package" comment="">
+      <change beforePath="$PROJECT_DIR$/test/changelist_foci/test_main.py" beforeDir="false" afterPath="$PROJECT_DIR$/test/changelist_foci/test_main.py" afterDir="false" />
+    </list>
+    <file path="$PROJECT_DIR$/test/changelist_foci/input/test_method_validate_input.py" ignored="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+</project>"""
 
 
 def test_main_invalid_arg_raises_exit(temp_cwd):
@@ -11,3 +95,244 @@ def test_main_invalid_arg_raises_exit(temp_cwd):
     with pytest.raises(SystemExit):
         main()
     sys.argv = sys.orig_argv
+
+
+def test_main_default_no_cl_data_file_raises_exit(temp_cwd):
+    sys.argv = ['cl-foci']
+    with pytest.raises(SystemExit, match='There are no Changelists.'):
+        main()
+
+
+def test_main_default_empty_cl_data_file_raises_exit(temp_cwd):
+    sys.argv = ['cl-foci']
+    # Create the Empty Changelist Data File.
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text("")
+    #
+    with pytest.raises(SystemExit, match='There are no Changelists.'):
+        main()
+
+
+def test_main_fx_empty_cl_data_file_raises_exit(temp_cwd):
+    sys.argv = ['cl-foci', '-fx']
+    # Create the Empty Changelist Data File.
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text("")
+    #
+    with pytest.raises(SystemExit, match='There are no Changelists.'):
+        main()
+
+
+def test_main_fax_empty_cl_data_file_raises_exit(temp_cwd):
+    sys.argv = ['cl-foci', '-fax']
+    # Create the Empty Changelist Data File.
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text("")
+    #
+    with pytest.raises(SystemExit, match='There are no Changelists.'):
+        main()
+
+
+def test_main_default_cl_data_file_no_lists_raises_exit(temp_cwd):
+    sys.argv = ['cl-foci']
+    # Create the Empty Changelist Data File.
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text("<changelists></changelists>")
+    #
+    with pytest.raises(SystemExit, match='There are no Changelists.'):
+        main()
+
+
+def test_main_default_cl_data_sample_1(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update changelist_foci/input/input_data.py
+* Update changelist_foci/input/argument_parser.py
+* Update changelist_foci/input/argument_data.py
+* Update changelist_foci/input/__init__.py""")
+
+
+def test_main_f_cl_data_sample_1(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci', '-f']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update input_data.py
+* Update argument_parser.py
+* Update argument_data.py
+* Update __init__.py""")
+
+
+def test_main_x_cl_data_sample_1(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci', '-x']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update changelist_foci/input/input_data
+* Update changelist_foci/input/argument_parser
+* Update changelist_foci/input/argument_data
+* Update changelist_foci/input/__init__""")
+
+
+def test_main_fx_cl_data_sample_1(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci', '-fx']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update input_data
+* Update argument_parser
+* Update argument_data
+* Update __init__""")
+
+
+def test_main_a_cl_data_sample_1(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci', '-a']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update changelist_foci/input/input_data.py
+* Update changelist_foci/input/argument_parser.py
+* Update changelist_foci/input/argument_data.py
+* Update changelist_foci/input/__init__.py
+
+CL-FOCI Main Package:
+* Update changelist_foci/__init__.py
+
+Test Fixtures & Data Providers:
+* Update test/changelist_foci/conftest.py
+
+Test Input Package:
+* Update test/changelist_foci/input/test_method_validate_input.py
+* Update test/changelist_foci/input/test_argument_parser.py
+
+Test Main Package:
+* Update test/changelist_foci/test_main.py""")
+
+
+def test_main_fa(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci', '-fa']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update input_data.py
+* Update argument_parser.py
+* Update argument_data.py
+* Update __init__.py
+
+CL-FOCI Main Package:
+* Update __init__.py
+
+Test Fixtures & Data Providers:
+* Update conftest.py
+
+Test Input Package:
+* Update test_method_validate_input.py
+* Update test_argument_parser.py
+
+Test Main Package:
+* Update test_main.py""")
+
+
+def test_main_fax_cl_data_sample_1(temp_cwd, monkeypatch):
+    sys.argv = ['cl-foci', '-fax']
+    collector = PrintCollector()
+    monkeypatch.setattr(builtins, 'print', collector.get_mock_print())
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    #
+    main()
+    collector.assert_expected("""CL-FOCI Input Package:
+* Update input_data
+* Update argument_parser
+* Update argument_data
+* Update __init__
+
+CL-FOCI Main Package:
+* Update __init__
+
+Test Fixtures & Data Providers:
+* Update conftest
+
+Test Input Package:
+* Update test_method_validate_input
+* Update test_argument_parser
+
+Test Main Package:
+* Update test_main""")
+
+
+def test_main_comment_workspace_sample_1(temp_cwd):
+    sys.argv = ['cl-foci', '-c']
+    #
+    WORKSPACE_DATA_FILE_PATH.parent.mkdir(parents=True)
+    WORKSPACE_DATA_FILE_PATH.touch()
+    WORKSPACE_DATA_FILE_PATH.write_text(WORKSPACE_DATA_SAMPLE_1)
+    #
+    main()
+    # Check the Workspace File for the output
+    result = WORKSPACE_DATA_FILE_PATH.read_text()
+    assert """CL-FOCI Input Package:
+* Update changelist_foci/input/input_data.py
+* Update changelist_foci/input/argument_parser.py
+* Update changelist_foci/input/argument_data.py
+* Update changelist_foci/input/__init__.py""" in result
+
+
+def test_main_comment_changelist_sample_1(temp_cwd):
+    sys.argv = ['cl-foci', '-c']
+    #
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    
+    main()
+    # Check the Changelist Data file for the output
+    result = CHANGELIST_DATA_FILE_PATH.read_text()
+    assert """CL-FOCI Input Package:
+* Update changelist_foci/input/input_data.py
+* Update changelist_foci/input/argument_parser.py
+* Update changelist_foci/input/argument_data.py
+* Update changelist_foci/input/__init__.py""" in result

--- a/test/changelist_foci/test_method_insert_foci_comments.py
+++ b/test/changelist_foci/test_method_insert_foci_comments.py
@@ -1,6 +1,5 @@
 """ Testing the Insert Foci Comments Method.
 """
-import sys
 import pytest
 from changelist_data.storage import load_storage
 

--- a/test/changelist_foci/test_method_insert_foci_comments.py
+++ b/test/changelist_foci/test_method_insert_foci_comments.py
@@ -5,7 +5,8 @@ from changelist_data.storage import load_storage
 
 from changelist_foci.format_options import FormatOptions
 from changelist_foci import insert_foci_comments
-from test.changelist_foci.conftest import CHANGELIST_DATA_FILE_PATH, CHANGELIST_DATA_SAMPLE_1
+from test.changelist_foci.conftest import CHANGELIST_DATA_FILE_PATH, CHANGELIST_DATA_SAMPLE_1, WORKSPACE_DATA_FILE_PATH, \
+    WORKSPACE_DATA_SAMPLE_1
 
 
 def test_insert_foci_comments_none_raises_exit():
@@ -25,12 +26,36 @@ def test_insert_foci_comments_cl_data_sample_1_default_format(temp_cwd):
         assert len(cl.comment) > len(cl.name)
 
 
-def test_insert_foci_comments_(temp_cwd):
+def test_insert_foci_comments_ws_data_sample_1_default_format(temp_cwd):
+    WORKSPACE_DATA_FILE_PATH.parent.mkdir(parents=True)
+    WORKSPACE_DATA_FILE_PATH.touch()
+    WORKSPACE_DATA_FILE_PATH.write_text(WORKSPACE_DATA_SAMPLE_1)
+    cl_data_storage = load_storage()
+    insert_foci_comments(cl_data_storage, FormatOptions())
+    #
+    result = cl_data_storage.get_changelists()
+    for cl in result:
+        assert len(cl.comment) > len(cl.name)
+
+
+def test_insert_foci_comments_cl_data_sample_1_fax_format(temp_cwd):
     CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
     CHANGELIST_DATA_FILE_PATH.touch()
     CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
     cl_data_storage = load_storage()
-    insert_foci_comments(cl_data_storage, FormatOptions())
+    insert_foci_comments(cl_data_storage, FormatOptions(no_file_ext=True, file_name=True))
+    #
+    result = cl_data_storage.get_changelists()
+    for cl in result:
+        assert len(cl.comment) > len(cl.name)
+
+
+def test_insert_foci_comments_ws_data_sample_1_fax_format(temp_cwd):
+    WORKSPACE_DATA_FILE_PATH.parent.mkdir(parents=True)
+    WORKSPACE_DATA_FILE_PATH.touch()
+    WORKSPACE_DATA_FILE_PATH.write_text(WORKSPACE_DATA_SAMPLE_1)
+    cl_data_storage = load_storage()
+    insert_foci_comments(cl_data_storage, FormatOptions(no_file_ext=True, file_name=True))
     #
     result = cl_data_storage.get_changelists()
     for cl in result:

--- a/test/changelist_foci/test_method_insert_foci_comments.py
+++ b/test/changelist_foci/test_method_insert_foci_comments.py
@@ -1,0 +1,39 @@
+""" Testing the Insert Foci Comments Method.
+"""
+import sys
+import pytest
+from changelist_data import load_storage
+
+from changelist_foci import insert_foci_comments, FormatOptions
+from test.changelist_foci.conftest import CHANGELIST_DATA_FILE_PATH, CHANGELIST_DATA_SAMPLE_1
+
+
+def test_insert_foci_comments_none_raises_exit():
+    with pytest.raises(AttributeError):
+        insert_foci_comments(None, FormatOptions()) 
+
+
+def test_insert_foci_comments_cl_data_sample_1_default_format(temp_cwd):
+    sys.argv = ['cl-foci']
+    
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    cl_data_storage = load_storage()
+    insert_foci_comments(cl_data_storage, FormatOptions())
+    #
+    result = cl_data_storage.get_changelists()
+    for cl in result:
+        assert len(cl.comment) > len(cl.name)
+
+
+def test_insert_foci_comments_(temp_cwd):
+    CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
+    CHANGELIST_DATA_FILE_PATH.touch()
+    CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)
+    cl_data_storage = load_storage()
+    insert_foci_comments(cl_data_storage, FormatOptions())
+    #
+    result = cl_data_storage.get_changelists()
+    for cl in result:
+        assert len(cl.comment) > len(cl.name)

--- a/test/changelist_foci/test_method_insert_foci_comments.py
+++ b/test/changelist_foci/test_method_insert_foci_comments.py
@@ -15,8 +15,6 @@ def test_insert_foci_comments_none_raises_exit():
 
 
 def test_insert_foci_comments_cl_data_sample_1_default_format(temp_cwd):
-    sys.argv = ['cl-foci']
-    #
     CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
     CHANGELIST_DATA_FILE_PATH.touch()
     CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)

--- a/test/changelist_foci/test_method_insert_foci_comments.py
+++ b/test/changelist_foci/test_method_insert_foci_comments.py
@@ -2,9 +2,10 @@
 """
 import sys
 import pytest
-from changelist_data import load_storage
+from changelist_data.storage import load_storage
 
-from changelist_foci import insert_foci_comments, FormatOptions
+from changelist_foci.format_options import FormatOptions
+from changelist_foci import insert_foci_comments
 from test.changelist_foci.conftest import CHANGELIST_DATA_FILE_PATH, CHANGELIST_DATA_SAMPLE_1
 
 
@@ -15,7 +16,7 @@ def test_insert_foci_comments_none_raises_exit():
 
 def test_insert_foci_comments_cl_data_sample_1_default_format(temp_cwd):
     sys.argv = ['cl-foci']
-    
+    #
     CHANGELIST_DATA_FILE_PATH.parent.mkdir(parents=True)
     CHANGELIST_DATA_FILE_PATH.touch()
     CHANGELIST_DATA_FILE_PATH.write_text(CHANGELIST_DATA_SAMPLE_1)


### PR DESCRIPTION
## CLI Option & Feature
### FOCI Workspace Comments: `-c` or `--comments
Alternative to printing FOCI to stdout.
- Removes 4 steps from IDEA commit workflows.

## Input Package Changes
### InputData Class
- Add Field: changelist_data_storage
  - Is present when FOCI should be inserted into storage
  - Is None when Workspace Comments feature is not in use (all previous use cases)

## Debugging
### Error Message from Data files with no Changelists
- Prevent stacktrace and errors from showing up in this scenario.
- Write a simple message: There are no Changelists.

## Workflow Improvements
- Use full hash codes for external action scripts versions
- Add workflow permissions where none were set

## Test Fixtures & Data Providers
- Add the `PrintCollector` mock class
- Add the `FileOutputCollector` mock class
- Add Changelist and Workspace XML file paths
- Add Changelist Data Sample 1
- Add Workspace Data Sample 1